### PR TITLE
Authorization booking

### DIFF
--- a/controllers/bookings.js
+++ b/controllers/bookings.js
@@ -167,15 +167,23 @@ exports.deleteBooking = async (req, res, next) => {
             return res.status(404).json({ success: false, message: `No Booking with the id of ${req.params.id}` });
         }
 
+        // Check if the user is the owner of the booking or an admin
+        if (booking.user.toString() !== req.user.id && req.user.role !== 'admin') {
+            return res.status(403).json({
+                success: false,
+                message: 'You are not authorized to delete this booking'
+            });
+        }
+
         await booking.deleteOne();
 
         res.status(200).json({
             success: true,
             data: {}
-        })
+        });
 
     } catch (error) {
         console.log(error);
-        return res.status(500).json({ success: false, message: "Cannot delete Booking" })
+        return res.status(500).json({ success: false, message: "Cannot delete Booking" });
     }
 };

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -585,46 +585,19 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Hotel'
-    post:
-      tags:
-        - Manager
-      summary: Create a new hotel
-      security:
-        - bearerAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Hotel'
-      responses:
-        '201':
-          description: Hotel created successfully
 
-  /manager/hotels/{id}:
+  /manager/hotels/{hotelId}:
     parameters:
-      - name: id
+      - name: hotelId
         in: path
         required: true
         schema:
           type: string
-    get:
-      tags:
-        - Manager
-      summary: Get hotel details
-      security:
-        - bearerAuth: []
-      responses:
-        '200':
-          description: Hotel details
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Hotel'
+    
     put:
       tags:
         - Manager
-      summary: Update hotel details
+      summary: Update hotel details managed by the current manager
       security:
         - bearerAuth: []
       requestBody:
@@ -636,26 +609,78 @@ paths:
       responses:
         '200':
           description: Hotel updated successfully
-    delete:
-      tags:
-        - Manager
-      summary: Delete hotel
-      security:
-        - bearerAuth: []
-      responses:
-        '200':
-          description: Hotel deleted successfully
 
-  /manager/roomtypes:
+  /manager/hotels/{hotelId}/bookings:
+    parameters:
+      - name: hotelId
+        in: path
+        required: true
+        schema:
+          type: string
     get:
       tags:
         - Manager
-      summary: Get all room types for managed hotels
+      summary: Get all bookings for a specific hotel managed by the current manager
       security:
         - bearerAuth: []
       responses:
         '200':
-          description: List of room types
+          description: List of bookings for the hotel
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Booking'
+
+  /manager/bookings/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+    put:
+      tags:
+        - Manager
+      summary: Update a booking managed by the current manager
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Booking'
+      responses:
+        '200':
+          description: Booking updated successfully
+    delete:
+      tags:
+        - Manager
+      summary: Delete a booking managed by the current manager
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Booking deleted successfully
+
+  /manager/hotels/{hotelId}/roomtypes:
+    parameters:
+      - name: hotelId
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      tags:
+        - Manager
+      summary: Get all room types for a specific hotel managed by the current manager
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: List of room types for the hotel
           content:
             application/json:
               schema:
@@ -665,7 +690,7 @@ paths:
     post:
       tags:
         - Manager
-      summary: Create a new room type
+      summary: Create a new room type for a specific hotel managed by the current manager
       security:
         - bearerAuth: []
       requestBody:
@@ -685,23 +710,10 @@ paths:
         required: true
         schema:
           type: string
-    get:
-      tags:
-        - Manager
-      summary: Get room type details
-      security:
-        - bearerAuth: []
-      responses:
-        '200':
-          description: Room type details
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RoomType'
     put:
       tags:
         - Manager
-      summary: Update room type details
+      summary: Update a room type managed by the current manager
       security:
         - bearerAuth: []
       requestBody:
@@ -716,7 +728,7 @@ paths:
     delete:
       tags:
         - Manager
-      summary: Delete room type
+      summary: Delete a room type managed by the current manager
       security:
         - bearerAuth: []
       responses:


### PR DESCRIPTION
This pull request introduces improvements to the booking deletion logic and updates to the API documentation in `swagger.yaml` to better reflect the manager's operations. The most important changes include adding authorization checks for booking deletion and restructuring the API paths and summaries for clarity and consistency.

### Authorization Enhancements:
* Added a check in `controllers/bookings.js` to ensure that only the booking owner or an admin can delete a booking. Unauthorized users now receive a `403 Forbidden` response.

### API Documentation Updates:
* **Hotel Management:**
  * Updated the `/manager/hotels/{hotelId}` endpoint to include a `PUT` method for updating hotel details managed by the current manager.
  * Updated the `/manager/hotels/{hotelId}/bookings` endpoint to retrieve all bookings for a specific hotel managed by the current manager.

* **Booking Management:**
  * Added a new `/manager/bookings/{id}` endpoint to allow managers to update or delete bookings they manage.

* **Room Type Management:**
  * Updated `/manager/hotels/{hotelId}/roomtypes` to allow managers to create, update, and delete room types for specific hotels they manage. Removed the `GET` method for retrieving room type details. [[1]](diffhunk://#diff-8b1949772e223a1da6a2049ada2733fa506410975b241cf86cf44c7a8665bc62L668-R693) [[2]](diffhunk://#diff-8b1949772e223a1da6a2049ada2733fa506410975b241cf86cf44c7a8665bc62L688-R716) [[3]](diffhunk://#diff-8b1949772e223a1da6a2049ada2733fa506410975b241cf86cf44c7a8665bc62L719-R731)